### PR TITLE
ESM TypeScript Resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,14 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "exports": {
-    "import": "./dist/index.mjs",
-    "require": "./dist/index.cjs"
+    "import": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.mjs"
+    },
+    "require": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.cjs"
+    }
   },
   "types": "./dist/index.d.ts",
   "sideEffects": false,


### PR DESCRIPTION
Was looking into using this project with my own Minecraft NBT parser, which is built to target ESM TypeScript. I'm not completely certain it was ESM module resolution that specifically caused the issue, but installing this project to my dependencies, TypeScript wasn't able to resolve the types accordingly.

After looking into the syntax that allows dual-packages to define ESM and CJS targets, I thought I'd try this dual-types description type. This indeed fixed the problem, I think it wasn't working before because TypeScript couldn't find type aliases from the `export` key, so maybe it can't use `types` in conjunction with `exports`.

https://stackoverflow.com/questions/58990498/package-json-exports-field-not-working-with-typescript

This was how I discovered this issue:

```sh
$ npm install mutf-8
```

```json
{
  "type": "module"
}
```

```ts
import { MUtf8Encoder } from "mutf-8";
// Could not find a declaration file for module 'mutf-8'. './node_modules/mutf-8/dist/index.mjs' implicitly has an 'any' type.
//  There are types at './node_modules/mutf-8/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'mutf-8' library may need to update its package.json or typings. ts(7016)
```