### PR TITLE
Improve compatibility with `TextDecoder`.

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -152,9 +152,9 @@ describe("MUtf8Decoder.decode", () => {
   test("fatal: detected invalid bytes when fatal is false", () => {
     const decoder = new MUtf8Decoder("mutf-8", { fatal: false });
     expect(decoder.decode(new Uint8Array([0x61, 0x80, 0x62]))).toBe("a\ufffdb");
-    expect(decoder.decode(new Uint8Array([0x61, 0xc0, 0x40, 0x62]))).toBe("a\ufffdb");
-    expect(decoder.decode(new Uint8Array([0x61, 0xe0, 0x40, 0x80, 0x62]))).toBe("a\ufffdb");
-    expect(decoder.decode(new Uint8Array([0x61, 0xe0, 0x80, 0x40, 0x62]))).toBe("a\ufffdb");
+    expect(decoder.decode(new Uint8Array([0x61, 0xc0, 0x40, 0x62]))).toBe("a\ufffd@b");
+    expect(decoder.decode(new Uint8Array([0x61, 0xe0, 0x40, 0x80, 0x62]))).toBe("a\ufffd@\ufffdb");
+    expect(decoder.decode(new Uint8Array([0x61, 0xe0, 0x80, 0x40, 0x62]))).toBe("a\ufffd\ufffd@b");
   });
 
   test("fatal: detected unexpected end when fatal is true", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,6 +122,7 @@ export class MUtf8Decoder {
         const b2 = buf[p++];
         if ((b2 & 0xc0) !== 0x80) {
           result.push(this.#handleError());
+          p--;
           continue;
         }
         result.push(String.fromCharCode(((b1 & 0x1f) << 6) | (b2 & 0x3f)));
@@ -132,9 +133,15 @@ export class MUtf8Decoder {
           continue;
         }
         const b2 = buf[p++];
-        const b3 = buf[p++];
-        if ((b2 & 0xc0) !== 0x80 || (b3 & 0xc0) !== 0x80) {
+        if ((b2 & 0xc0) !== 0x80) {
           result.push(this.#handleError());
+          p--;
+          continue;
+        }
+        const b3 = buf[p++];
+        if ((b3 & 0xc0) !== 0x80) {
+          result.push(this.#handleError());
+          p -= 2;
           continue;
         }
         if (p === 3 && b1 === 0xef && b2 === 0xbb && b3 === 0xbf && !this.ignoreBOM) {


### PR DESCRIPTION
The behavior for inserting a REPLACEMENT CHARACTER upon detecting an invalid byte has been adjusted to align with the `TextDecoder` 's implementation.