### PR TITLE
Add Dev Container configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:22
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG GROOVY_VERSION=4.0.27
+
+# Set `DEVCONTAINER` environment variable to help with orientation
+ENV DEVCONTAINER=true
+
+RUN apt-get update && \
+    apt-get dist-upgrade -y --no-install-recommends && \
+    apt-get install -y --no-install-recommends \
+      curl \
+      git \
+      openjdk-17-jdk-headless \
+      sudo \
+      unzip \
+      zip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    usermod -aG sudo node && \
+    echo "node ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers.d/node && \
+    curl -fsSLO "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-$GROOVY_VERSION.zip" && \
+    unzip "apache-groovy-binary-$GROOVY_VERSION.zip" -d /usr/local && \
+    rm -f "apache-groovy-binary-$GROOVY_VERSION.zip" && \
+    ln -s "/usr/local/groovy-$GROOVY_VERSION/bin/groovy" /usr/local/bin/groovy && \
+    ln -s "/usr/local/groovy-$GROOVY_VERSION/bin/groovyc" /usr/local/bin/groovyc && \
+    ln -s "/usr/local/groovy-$GROOVY_VERSION/bin/groovydoc" /usr/local/bin/groovydoc && \
+    ln -s "/usr/local/groovy-$GROOVY_VERSION/bin/groovysh" /usr/local/bin/groovysh
+
+USER node

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "mutf-8",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "remoteUser": "node",
+  "customizations": {
+    "vscode": {
+      "extensions": ["EditorConfig.EditorConfig", "biomejs.biome"],
+      "settings": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "biomejs.biome"
+      }
+    }
+  }
+}

--- a/biome.json
+++ b/biome.json
@@ -6,8 +6,7 @@
 		"useIgnoreFile": true
 	},
 	"files": {
-		"ignoreUnknown": false,
-		"ignore": ["**/testdata.*"]
+		"ignoreUnknown": false
 	},
 	"formatter": {
 		"enabled": true,

--- a/package.json
+++ b/package.json
@@ -9,8 +9,14 @@
     "packages/mutf-8-stream"
   ],
   "scripts": {
-    "testdata": "./scripts/gen-testdatacode.groovy testdata.json",
-    "docs": "typedoc --out docs"
+    "build": "npm run build --workspaces",
+    "check": "npm run check --workspaces",
+    "clean": "npm run clean --workspaces",
+    "compile": "npm run compile --workspaces",
+    "docs": "typedoc --out docs",
+    "lint": "npm run lint --workspaces",
+    "test": "npm run test --workspaces",
+    "testdata": "./scripts/gen-testdatacode.groovy testdata.json"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/packages/mutf-8-stream/src/index.test.mts
+++ b/packages/mutf-8-stream/src/index.test.mts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 import { describe, expect, test } from "vitest";
-import testdata from "../../../testdata.mts";
+import testdata from "../../../testdata.mjs";
 import { MUtf8DecoderStream, MUtf8EncoderStream } from "./index.js";
 
 describe("MUtf8DecoderStream", () => {

--- a/packages/mutf-8/src/index.test.mts
+++ b/packages/mutf-8/src/index.test.mts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 import { describe, expect, test } from "vitest";
-import testdata from "../../../testdata.mts";
+import testdata from "../../../testdata.mjs";
 import { MUtf8Decoder, MUtf8Encoder } from "./index.js";
 
 describe("MUtf8Decoder.decode()", () => {


### PR DESCRIPTION
Provides a basic Dev Container configuration suitable for coding, building, testing, and Git operations.

Does not include opinionated tools; developers can install extras as needed.