### PR TITLE
Improve decoding performance.

### DIFF
--- a/packages/mutf-8/package.json
+++ b/packages/mutf-8/package.json
@@ -44,7 +44,8 @@
     "lint:ci": "biome check src",
     "prepack": "cpx ../../{LICENSE,README.md} .",
     "prepublishOnly": "npm run build",
-    "test": "vitest run --typecheck.tsconfig tsconfig.test.json"
+    "test": "vitest run --typecheck.tsconfig tsconfig.test.json",
+    "bench": "vitest bench --typecheck.tsconfig tsconfig.test.json"
   },
   "sideEffects": false,
   "module": "./dist/index.mjs"

--- a/packages/mutf-8/src/index.bench.mts
+++ b/packages/mutf-8/src/index.bench.mts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+
+import { bench, describe } from "vitest";
+import { MUtf8Decoder, MUtf8Encoder } from "./index.js";
+
+const encoder = new MUtf8Encoder();
+const decoder = new MUtf8Decoder();
+
+describe("MUtf8Decoder.decode", () => {
+  describe("ASCII text", () => {
+    const asciiText = "The quick brown fox jumps over the lazy dog.";
+    const asciiBytes500 = encoder.encode(stretch(asciiText, 500));
+    const asciiBytes5K = encoder.encode(stretch(asciiText, 5000));
+    const asciiBytes50K = encoder.encode(stretch(asciiText, 50000));
+
+    bench("decode 500 length string", () => {
+      decoder.decode(asciiBytes500);
+    });
+
+    bench("decode 5K length string", () => {
+      decoder.decode(asciiBytes5K);
+    });
+
+    bench("decode 50K length string", () => {
+      decoder.decode(asciiBytes50K);
+    });
+  });
+
+  describe("Latin-1 text", () => {
+    const latinText = "Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich.";
+    const latin1Bytes500 = encoder.encode(stretch(latinText, 500));
+    const latin1Bytes5K = encoder.encode(stretch(latinText, 5000));
+    const latin1Bytes50K = encoder.encode(stretch(latinText, 50000));
+
+    bench("decode 500 length string", () => {
+      decoder.decode(latin1Bytes500);
+    });
+
+    bench("decode 5K length string", () => {
+      decoder.decode(latin1Bytes5K);
+    });
+
+    bench("decode 50K length string", () => {
+      decoder.decode(latin1Bytes50K);
+    });
+  });
+
+  describe("Asian text", () => {
+    const asianText = "あのイーハトーヴォのすきとおった風、夏でも底に冷たさをもつ青いそら";
+    const asianBytes500 = encoder.encode(stretch(asianText, 500));
+    const asianBytes5K = encoder.encode(stretch(asianText, 5000));
+    const asianBytes50K = encoder.encode(stretch(asianText, 50000));
+
+    bench("decode 500 length string", () => {
+      decoder.decode(asianBytes500);
+    });
+
+    bench("decode 5K length string", () => {
+      decoder.decode(asianBytes5K);
+    });
+
+    bench("decode 50K length string", () => {
+      decoder.decode(asianBytes50K);
+    });
+  });
+
+  describe("Emoji text", () => {
+    const emojiText = "😀😃😄😁😆😅😂🤣😊😇🙂🙃😉😌😍🥰😘😗😙😚";
+    const emojiBytes500 = encoder.encode(stretch(emojiText, 500));
+    const emojiBytes5K = encoder.encode(stretch(emojiText, 5000));
+    const emojiBytes50K = encoder.encode(stretch(emojiText, 50000));
+
+    bench("decode 500 length string", () => {
+      decoder.decode(emojiBytes500);
+    });
+
+    bench("decode 5K length string", () => {
+      decoder.decode(emojiBytes5K);
+    });
+
+    bench("decode 50K length string", () => {
+      decoder.decode(emojiBytes50K);
+    });
+  });
+
+  describe("Mixed text", () => {
+    const mixedText =
+      "The quick brown fox jumps over the lazy dog. Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich. あのイーハトーヴォのすきとおった風、夏でも底に冷たさをもつ青いそら 😀😃😄😁😆😅😂🤣😊😇🙂🙃😉😌😍🥰😘😗😙😚";
+    const mixedBytes500 = encoder.encode(stretch(mixedText, 500));
+    const mixedBytes5K = encoder.encode(stretch(mixedText, 5000));
+    const mixedBytes50K = encoder.encode(stretch(mixedText, 50000));
+
+    bench("decode 500 length string", () => {
+      decoder.decode(mixedBytes500);
+    });
+
+    bench("decode 5K length string", () => {
+      decoder.decode(mixedBytes5K);
+    });
+
+    bench("decode 50K length string", () => {
+      decoder.decode(mixedBytes50K);
+    });
+  });
+});
+
+function stretch(text: string, length: number): string {
+  return text.repeat(Math.ceil(length / text.length)).slice(0, length);
+}


### PR DESCRIPTION
Convert character codes to string in a single operation, rather than building the string incrementally.

before modification:

```plaintext
 ✓ src/index.bench.mts > MUtf8Decoder.decode > ASCII text 1866ms
     name                              hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · decode 500 length string  138,611.30  0.0064  0.3600  0.0072  0.0072  0.0102  0.0129  0.0169  ±0.26%    69306
   · decode 5K length string    13,134.21  0.0683  0.3238  0.0761  0.0761  0.1715  0.1915  0.2576  ±0.48%     6568
   · decode 50K length string      781.09  1.1058  2.2982  1.2803  1.2347  2.1919  2.2186  2.2982  ±2.14%      391

 ✓ src/index.bench.mts > MUtf8Decoder.decode > Latin-1 text 1851ms
     name                              hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · decode 500 length string  133,635.72  0.0067  2.6423  0.0075  0.0075  0.0098  0.0119  0.0185  ±1.05%    66818
   · decode 5K length string    12,589.96  0.0713  0.3823  0.0794  0.0790  0.1731  0.1864  0.2431  ±0.46%     6296
   · decode 50K length string      754.70  1.1506  2.4067  1.3250  1.2599  2.3257  2.3311  2.4067  ±2.30%      378

 ✓ src/index.bench.mts > MUtf8Decoder.decode > Asian text 1840ms
     name                              hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · decode 500 length string  110,335.96  0.0081  0.3298  0.0091  0.0089  0.0156  0.0177  0.1103  ±0.49%    55168
   · decode 5K length string    10,826.64  0.0839  0.4914  0.0924  0.0893  0.2458  0.2576  0.3631  ±0.73%     5414
   · decode 50K length string      673.34  1.3122  2.4855  1.4851  1.4170  2.3558  2.3750  2.4855  ±2.09%      337

 ✓ src/index.bench.mts > MUtf8Decoder.decode > Emoji text 1844ms
     name                              hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · decode 500 length string  111,678.43  0.0080  0.3261  0.0090  0.0088  0.0124  0.0168  0.1117  ±0.48%    55840
   · decode 5K length string    10,886.18  0.0836  0.3125  0.0919  0.0892  0.2414  0.2483  0.3017  ±0.67%     5444
   · decode 50K length string      666.79  1.3056  3.0636  1.4997  1.4367  2.4745  2.5018  3.0636  ±2.22%      334

 ✓ src/index.bench.mts > MUtf8Decoder.decode > Mixed text 1839ms
     name                              hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · decode 500 length string  119,653.83  0.0073  0.2694  0.0084  0.0082  0.0153  0.0168  0.1213  ±0.51%    59827
   · decode 5K length string    11,678.15  0.0780  0.4179  0.0856  0.0838  0.1895  0.2087  0.3173  ±0.57%     5840
   · decode 50K length string      658.66  1.2233  3.6836  1.5182  1.3851  3.5177  3.5536  3.6836  ±3.97%      330
```

after modification:

```plaintext
✓ src/index.bench.mts > MUtf8Decoder.decode > ASCII text 1984ms
     name                              hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · decode 500 length string  631,249.25  0.0013  0.6348  0.0016  0.0016  0.0024  0.0031  0.0106  ±0.52%   315625
   · decode 5K length string    66,023.80  0.0133  1.6001  0.0151  0.0148  0.0223  0.0291  0.1111  ±0.77%    33012
   · decode 50K length string    3,699.06  0.2357  1.4752  0.2703  0.2538  1.0566  1.1133  1.2945  ±2.12%     1850

 ✓ src/index.bench.mts > MUtf8Decoder.decode > Latin-1 text 1939ms
     name                              hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · decode 500 length string  460,527.54  0.0017  0.2494  0.0022  0.0021  0.0035  0.0041  0.0159  ±0.51%   230264
   · decode 5K length string    50,625.04  0.0170  1.8923  0.0198  0.0191  0.0353  0.0982  0.1172  ±0.88%    25313
   · decode 50K length string    2,298.99  0.3648  1.6079  0.4350  0.4136  1.3263  1.4626  1.5747  ±2.45%     1150

 ✓ src/index.bench.mts > MUtf8Decoder.decode > Asian text 1887ms
     name                              hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · decode 500 length string  274,637.11  0.0030  0.1704  0.0036  0.0036  0.0050  0.0065  0.0894  ±0.46%   137319
   · decode 5K length string    28,562.43  0.0306  1.4384  0.0350  0.0337  0.1142  0.1183  0.1561  ±0.78%    14282
   · decode 50K length string    1,293.43  0.6591  1.7620  0.7731  0.7301  1.5647  1.6226  1.7620  ±2.20%      647

 ✓ src/index.bench.mts > MUtf8Decoder.decode > Emoji text 1885ms
     name                              hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · decode 500 length string  274,088.16  0.0031  0.3078  0.0036  0.0036  0.0054  0.0067  0.0900  ±0.48%   137045
   · decode 5K length string    28,172.99  0.0309  1.4373  0.0355  0.0338  0.1173  0.1223  0.1745  ±0.81%    14087
   · decode 50K length string    1,284.75  0.6536  1.7045  0.7784  0.7346  1.5826  1.6540  1.7045  ±2.32%      643

 ✓ src/index.bench.mts > MUtf8Decoder.decode > Mixed text 1908ms
     name                              hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · decode 500 length string  356,024.68  0.0022  0.2942  0.0028  0.0028  0.0049  0.0055  0.0168  ±0.50%   178013
   · decode 5K length string    37,972.70  0.0233  1.3814  0.0263  0.0259  0.0420  0.1098  0.1268  ±0.71%    18987
   · decode 50K length string    1,664.44  0.4829  3.8879  0.6008  0.5634  1.5879  1.6358  3.8879  ±2.87%      833
```