### PR TITLE
Improve encoding performance.

### DIFF
--- a/packages/mutf-8/src/index.bench.mts
+++ b/packages/mutf-8/src/index.bench.mts
@@ -3,12 +3,17 @@
 import { bench, describe } from "vitest";
 import { MUtf8Decoder, MUtf8Encoder } from "./index.js";
 
+const asciiText = "The quick brown fox jumps over the lazy dog.";
+const latinText = "Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich.";
+const asianText = "あのイーハトーヴォのすきとおった風、夏でも底に冷たさをもつ青いそら";
+const emojiText = "😀😃😄😁😆😅😂🤣😊😇🙂🙃😉😌😍🥰😘😗😙😚";
+const mixedText = `${asciiText} ${latinText} ${asianText} ${emojiText}`;
+
 const encoder = new MUtf8Encoder();
 const decoder = new MUtf8Decoder();
 
 describe("MUtf8Decoder.decode", () => {
   describe("ASCII text", () => {
-    const asciiText = "The quick brown fox jumps over the lazy dog.";
     const asciiBytes500 = encoder.encode(stretch(asciiText, 500));
     const asciiBytes5K = encoder.encode(stretch(asciiText, 5000));
     const asciiBytes50K = encoder.encode(stretch(asciiText, 50000));
@@ -27,7 +32,6 @@ describe("MUtf8Decoder.decode", () => {
   });
 
   describe("Latin-1 text", () => {
-    const latinText = "Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich.";
     const latin1Bytes500 = encoder.encode(stretch(latinText, 500));
     const latin1Bytes5K = encoder.encode(stretch(latinText, 5000));
     const latin1Bytes50K = encoder.encode(stretch(latinText, 50000));
@@ -46,7 +50,6 @@ describe("MUtf8Decoder.decode", () => {
   });
 
   describe("Asian text", () => {
-    const asianText = "あのイーハトーヴォのすきとおった風、夏でも底に冷たさをもつ青いそら";
     const asianBytes500 = encoder.encode(stretch(asianText, 500));
     const asianBytes5K = encoder.encode(stretch(asianText, 5000));
     const asianBytes50K = encoder.encode(stretch(asianText, 50000));
@@ -65,7 +68,6 @@ describe("MUtf8Decoder.decode", () => {
   });
 
   describe("Emoji text", () => {
-    const emojiText = "😀😃😄😁😆😅😂🤣😊😇🙂🙃😉😌😍🥰😘😗😙😚";
     const emojiBytes500 = encoder.encode(stretch(emojiText, 500));
     const emojiBytes5K = encoder.encode(stretch(emojiText, 5000));
     const emojiBytes50K = encoder.encode(stretch(emojiText, 50000));
@@ -84,8 +86,6 @@ describe("MUtf8Decoder.decode", () => {
   });
 
   describe("Mixed text", () => {
-    const mixedText =
-      "The quick brown fox jumps over the lazy dog. Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich. あのイーハトーヴォのすきとおった風、夏でも底に冷たさをもつ青いそら 😀😃😄😁😆😅😂🤣😊😇🙂🙃😉😌😍🥰😘😗😙😚";
     const mixedBytes500 = encoder.encode(stretch(mixedText, 500));
     const mixedBytes5K = encoder.encode(stretch(mixedText, 5000));
     const mixedBytes50K = encoder.encode(stretch(mixedText, 50000));
@@ -100,6 +100,192 @@ describe("MUtf8Decoder.decode", () => {
 
     bench("decode 50K length string", () => {
       decoder.decode(mixedBytes50K);
+    });
+  });
+});
+
+describe("MUtf8Encoder.encode", () => {
+  describe("ASCII text", () => {
+    const asciiText500 = stretch(asciiText, 500);
+    const asciiText5K = stretch(asciiText, 5000);
+    const asciiText50K = stretch(asciiText, 50000);
+
+    bench("encode 500 length string", () => {
+      encoder.encode(asciiText500);
+    });
+
+    bench("encode 5K length string", () => {
+      encoder.encode(asciiText5K);
+    });
+
+    bench("encode 50K length string", () => {
+      encoder.encode(asciiText50K);
+    });
+  });
+
+  describe("Latin-1 text", () => {
+    const latinText500 = stretch(latinText, 500);
+    const latinText5K = stretch(latinText, 5000);
+    const latinText50K = stretch(latinText, 50000);
+
+    bench("encode 500 length string", () => {
+      encoder.encode(latinText500);
+    });
+
+    bench("encode 5K length string", () => {
+      encoder.encode(latinText5K);
+    });
+
+    bench("encode 50K length string", () => {
+      encoder.encode(latinText50K);
+    });
+  });
+
+  describe("Asian text", () => {
+    const asianText500 = stretch(asianText, 500);
+    const asianText5K = stretch(asianText, 5000);
+    const asianText50K = stretch(asianText, 50000);
+
+    bench("encode 500 length string", () => {
+      encoder.encode(asianText500);
+    });
+
+    bench("encode 5K length string", () => {
+      encoder.encode(asianText5K);
+    });
+
+    bench("encode 50K length string", () => {
+      encoder.encode(asianText50K);
+    });
+  });
+
+  describe("Emoji text", () => {
+    const emojiText500 = stretch(emojiText, 500);
+    const emojiText5K = stretch(emojiText, 5000);
+    const emojiText50K = stretch(emojiText, 50000);
+
+    bench("encode 500 length string", () => {
+      encoder.encode(emojiText500);
+    });
+
+    bench("encode 5K length string", () => {
+      encoder.encode(emojiText5K);
+    });
+
+    bench("encode 50K length string", () => {
+      encoder.encode(emojiText50K);
+    });
+  });
+
+  describe("Mixed text", () => {
+    const mixedText500 = stretch(mixedText, 500);
+    const mixedText5K = stretch(mixedText, 5000);
+    const mixedText50K = stretch(mixedText, 50000);
+
+    bench("encode 500 length string", () => {
+      encoder.encode(mixedText500);
+    });
+
+    bench("encode 5K length string", () => {
+      encoder.encode(mixedText5K);
+    });
+
+    bench("encode 50K length string", () => {
+      encoder.encode(mixedText50K);
+    });
+  });
+});
+
+describe("MUtf8Encoder.encodeInto", () => {
+  const buffer = new Uint8Array(800000);
+
+  describe("ASCII text", () => {
+    const asciiText500 = stretch(asciiText, 500);
+    const asciiText5K = stretch(asciiText, 5000);
+    const asciiText50K = stretch(asciiText, 50000);
+
+    bench("encode 500 length string", () => {
+      encoder.encodeInto(asciiText500, buffer);
+    });
+
+    bench("encode 5K length string", () => {
+      encoder.encodeInto(asciiText5K, buffer);
+    });
+
+    bench("encode 50K length string", () => {
+      encoder.encodeInto(asciiText50K, buffer);
+    });
+  });
+
+  describe("Latin-1 text", () => {
+    const latinText500 = stretch(latinText, 500);
+    const latinText5K = stretch(latinText, 5000);
+    const latinText50K = stretch(latinText, 50000);
+
+    bench("encode 500 length string", () => {
+      encoder.encodeInto(latinText500, buffer);
+    });
+
+    bench("encode 5K length string", () => {
+      encoder.encodeInto(latinText5K, buffer);
+    });
+
+    bench("encode 50K length string", () => {
+      encoder.encodeInto(latinText50K, buffer);
+    });
+  });
+
+  describe("Asian text", () => {
+    const asianText500 = stretch(asianText, 500);
+    const asianText5K = stretch(asianText, 5000);
+    const asianText50K = stretch(asianText, 50000);
+
+    bench("encode 500 length string", () => {
+      encoder.encodeInto(asianText500, buffer);
+    });
+
+    bench("encode 5K length string", () => {
+      encoder.encodeInto(asianText5K, buffer);
+    });
+
+    bench("encode 50K length string", () => {
+      encoder.encodeInto(asianText50K, buffer);
+    });
+  });
+
+  describe("Emoji text", () => {
+    const emojiText500 = stretch(emojiText, 500);
+    const emojiText5K = stretch(emojiText, 5000);
+    const emojiText50K = stretch(emojiText, 50000);
+
+    bench("encode 500 length string", () => {
+      encoder.encodeInto(emojiText500, buffer);
+    });
+
+    bench("encode 5K length string", () => {
+      encoder.encodeInto(emojiText5K, buffer);
+    });
+
+    bench("encode 50K length string", () => {
+      encoder.encodeInto(emojiText50K, buffer);
+    });
+  });
+
+  describe("Mixed text", () => {
+    const mixedText500 = stretch(mixedText, 500);
+    const mixedText5K = stretch(mixedText, 5000);
+    const mixedText50K = stretch(mixedText, 50000);
+
+    bench("encode 500 length string", () => {
+      encoder.encodeInto(mixedText500, buffer);
+    });
+
+    bench("encode 5K length string", () => {
+      encoder.encodeInto(mixedText5K, buffer);
+    });
+
+    bench("encode 50K length string", () => {
+      encoder.encodeInto(mixedText50K, buffer);
     });
   });
 });

--- a/packages/mutf-8/src/index.test.mts
+++ b/packages/mutf-8/src/index.test.mts
@@ -96,8 +96,8 @@ describe("MUtf8Encoder.encode()", () => {
   });
 
   test.each(testdata)("encode the text: $text", ({ text, binary }) => {
-    const decoder = new MUtf8Decoder();
-    expect(decoder.decode(binary)).toBe(text);
+    const encoder = new MUtf8Encoder();
+    expect(encoder.encode(text)).toEqual(binary);
   });
 });
 


### PR DESCRIPTION
- Use pre-allocated `Uint8Array` instead of the temporary array.
- Refer to a code point using UTF-16 code units index.

before modification:

```plaintext
 ✓ src/index.bench.mts > MUtf8Encoder.encode > ASCII text 1876ms
     name                              hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · encode 500 length string  204,910.23  0.0042  0.2787  0.0049  0.0048  0.0073  0.0110  0.0446  ±0.45%   102456
   · encode 5K length string    20,993.98  0.0432  0.2454  0.0476  0.0465  0.1301  0.1415  0.1826  ±0.47%    10498
   · encode 50K length string    1,188.32  0.6982  1.8756  0.8415  0.8079  1.8110  1.8579  1.8756  ±2.46%      595

 ✓ src/index.bench.mts > MUtf8Encoder.encode > Latin-1 text 1868ms
     name                              hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · encode 500 length string  191,632.19  0.0045  0.3831  0.0052  0.0052  0.0074  0.0098  0.0958  ±0.48%    95817
   · encode 5K length string    19,192.51  0.0467  0.3264  0.0521  0.0508  0.1381  0.1517  0.2265  ±0.54%     9597
   · encode 50K length string      891.91  0.9137  2.5256  1.1212  1.0487  2.2296  2.3422  2.5256  ±2.93%      446

 ✓ src/index.bench.mts > MUtf8Encoder.encode > Asian text 1846ms
     name                             hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · encode 500 length string  97,373.32  0.0083  4.0912  0.0103  0.0098  0.0202  0.0308  0.1073  ±1.70%    48687
   · encode 5K length string   11,495.23  0.0742  0.3103  0.0870  0.0833  0.1869  0.1938  0.2447  ±0.66%     5748
   · encode 50K length string     399.64  2.0307  5.4699  2.5023  3.0745  3.6265  3.6507  5.4699  ±2.97%      200

 ✓ src/index.bench.mts > MUtf8Encoder.encode > Emoji text 1846ms
     name                              hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · encode 500 length string  109,493.72  0.0072  0.3432  0.0091  0.0087  0.0185  0.0242  0.1270  ±0.74%    54747
   · encode 5K length string    13,135.37  0.0642  0.3799  0.0761  0.0722  0.1858  0.1942  0.2297  ±0.75%     6568
   · encode 50K length string      419.50  1.8720  9.1875  2.3838  2.9676  3.3022  3.8232  9.1875  ±3.84%      210

 ✓ src/index.bench.mts > MUtf8Encoder.encode > Mixed text 1852ms
     name                              hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · encode 500 length string  136,318.01  0.0061  0.3701  0.0073  0.0072  0.0117  0.0163  0.1084  ±0.56%    68160
   · encode 5K length string    15,802.18  0.0567  0.4229  0.0633  0.0610  0.1663  0.1755  0.2433  ±0.63%     7902
   · encode 50K length string      611.91  1.3029  6.2503  1.6342  1.5072  2.7588  3.6287  6.2503  ±3.65%      306

✓ src/index.bench.mts > MUtf8Encoder.encodeInto > ASCII text 1910ms
     name                                  hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · encodeInto 500 length string  342,078.18  0.0028  0.0440  0.0029  0.0029  0.0042  0.0054  0.0059  ±0.05%   171040
   · encodeInto 5K length string    35,289.05  0.0274  0.0896  0.0283  0.0287  0.0330  0.0340  0.0475  ±0.09%    17645
   · encodeInto 50K length string    3,348.02  0.2740  0.4861  0.2987  0.2989  0.3435  0.3747  0.4809  ±0.24%     1675

 ✓ src/index.bench.mts > MUtf8Encoder.encodeInto > Latin-1 text 1885ms
     name                                  hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · encodeInto 500 length string  292,969.79  0.0033  0.0239  0.0034  0.0034  0.0038  0.0045  0.0056  ±0.03%   146485
   · encodeInto 5K length string    29,872.93  0.0323  0.0984  0.0335  0.0334  0.0377  0.0389  0.0492  ±0.07%    14937
   · encodeInto 50K length string    2,880.99  0.3311  0.5602  0.3471  0.3476  0.4349  0.4405  0.5200  ±0.30%     1441

 ✓ src/index.bench.mts > MUtf8Encoder.encodeInto > Asian text 1864ms
     name                                  hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · encodeInto 500 length string  220,954.56  0.0041  0.1988  0.0045  0.0045  0.0064  0.0083  0.0201  ±0.41%   110478
   · encodeInto 5K length string    22,290.93  0.0406  1.7181  0.0449  0.0449  0.0758  0.1422  0.1895  ±0.79%    11146
   · encodeInto 50K length string    2,238.89  0.4078  0.8167  0.4466  0.4479  0.6162  0.6644  0.8028  ±0.57%     1120

 ✓ src/index.bench.mts > MUtf8Encoder.encodeInto > Emoji text 1888ms
     name                                  hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · encodeInto 500 length string  295,352.94  0.0031  0.1797  0.0034  0.0034  0.0039  0.0052  0.0162  ±0.32%   147677
   · encodeInto 5K length string    28,232.04  0.0306  1.2291  0.0354  0.0350  0.0521  0.0627  0.1701  ±0.62%    14117
   · encodeInto 50K length string    2,968.08  0.3082  0.6479  0.3369  0.3368  0.4378  0.4568  0.5409  ±0.37%     1485

 ✓ src/index.bench.mts > MUtf8Encoder.encodeInto > Mixed text 1881ms
     name                                  hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · encodeInto 500 length string  269,725.70  0.0033  0.3533  0.0037  0.0037  0.0045  0.0058  0.0161  ±0.34%   134876
   · encodeInto 5K length string    27,763.01  0.0331  0.2923  0.0360  0.0360  0.0514  0.0558  0.1699  ±0.32%    13882
   · encodeInto 50K length string    2,768.21  0.3347  1.6438  0.3612  0.3605  0.4748  0.4949  0.6136  ±0.60%     1385
```

after modification:

```plaintext
 ✓ src/index.bench.mts > MUtf8Encoder.encode > ASCII text 1907ms
     name                              hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · encode 500 length string  321,221.55  0.0027  3.0556  0.0031  0.0031  0.0048  0.0054  0.0103  ±1.84%   160611
   · encode 5K length string    36,977.16  0.0255  0.5015  0.0270  0.0272  0.0344  0.0415  0.0517  ±0.30%    18489
   · encode 50K length string    3,671.80  0.2518  0.8761  0.2723  0.2751  0.2952  0.3007  0.6813  ±0.32%     1836

 ✓ src/index.bench.mts > MUtf8Encoder.encode > Latin-1 text 1890ms
     name                              hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · encode 500 length string  266,376.50  0.0034  1.8720  0.0038  0.0037  0.0053  0.0059  0.0118  ±0.87%   133189
   · encode 5K length string    29,320.80  0.0318  0.5049  0.0341  0.0339  0.0434  0.0495  0.0657  ±0.26%    14661
   · encode 50K length string    2,972.15  0.3234  0.9451  0.3365  0.3373  0.3744  0.3800  0.9135  ±0.37%     1487

 ✓ src/index.bench.mts > MUtf8Encoder.encode > Asian text 1875ms
     name                              hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · encode 500 length string  226,432.71  0.0039  0.5081  0.0044  0.0043  0.0084  0.0099  0.0149  ±0.40%   113217
   · encode 5K length string    25,706.27  0.0357  0.6053  0.0389  0.0390  0.0544  0.0667  0.0755  ±0.38%    12854
   · encode 50K length string    2,664.50  0.3535  1.0323  0.3753  0.3760  0.4567  0.5615  0.8802  ±0.50%     1333

 ✓ src/index.bench.mts > MUtf8Encoder.encode > Emoji text 1888ms
     name                              hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · encode 500 length string  245,279.03  0.0035  0.6170  0.0041  0.0040  0.0088  0.0095  0.0139  ±0.42%   122640
   · encode 5K length string    29,302.72  0.0317  1.3591  0.0341  0.0336  0.0590  0.0637  0.0771  ±0.72%    14652
   · encode 50K length string    2,815.21  0.3254  0.7816  0.3552  0.3566  0.4273  0.4677  0.7290  ±0.37%     1408

 ✓ src/index.bench.mts > MUtf8Encoder.encode > Mixed text 1889ms
     name                              hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · encode 500 length string  251,788.38  0.0035  0.5547  0.0040  0.0040  0.0058  0.0065  0.0128  ±0.24%   125895
   · encode 5K length string    27,810.95  0.0341  0.3361  0.0360  0.0358  0.0442  0.0498  0.0613  ±0.22%    13906
   · encode 50K length string    2,865.14  0.3359  0.8966  0.3490  0.3490  0.3961  0.4329  0.8254  ±0.37%     1433

✓ src/index.bench.mts > MUtf8Encoder.encodeInto > ASCII text 2003ms
     name                                  hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · encodeInto 500 length string  713,986.89  0.0014  0.0456  0.0014  0.0014  0.0020  0.0025  0.0033  ±0.05%   356994
   · encodeInto 5K length string    74,599.88  0.0131  0.5683  0.0134  0.0132  0.0179  0.0191  0.0283  ±0.23%    37300
   · encodeInto 50K length string    7,041.07  0.1310  0.2471  0.1420  0.1431  0.1661  0.1951  0.2409  ±0.25%     3521

 ✓ src/index.bench.mts > MUtf8Encoder.encodeInto > Latin-1 text 1949ms
     name                                  hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · encodeInto 500 length string  555,684.32  0.0017  0.3314  0.0018  0.0018  0.0020  0.0024  0.0034  ±0.13%   277843
   · encodeInto 5K length string    57,743.79  0.0164  0.0357  0.0173  0.0175  0.0198  0.0204  0.0257  ±0.05%    28872
   · encodeInto 50K length string    5,820.96  0.1621  0.3268  0.1718  0.1720  0.1976  0.2172  0.2956  ±0.21%     2911

 ✓ src/index.bench.mts > MUtf8Encoder.encodeInto > Asian text 1918ms
     name                                  hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · encodeInto 500 length string  397,311.99  0.0022  0.0209  0.0025  0.0026  0.0030  0.0039  0.0050  ±0.04%   198656
   · encodeInto 5K length string    40,626.60  0.0215  0.1316  0.0246  0.0251  0.0303  0.0327  0.0473  ±0.12%    20314
   · encodeInto 50K length string    4,133.99  0.2152  0.3734  0.2419  0.2503  0.2891  0.3217  0.3541  ±0.32%     2067

 ✓ src/index.bench.mts > MUtf8Encoder.encodeInto > Emoji text 1926ms
     name                                  hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · encodeInto 500 length string  468,633.87  0.0020  0.0189  0.0021  0.0021  0.0025  0.0029  0.0038  ±0.03%   234317
   · encodeInto 5K length string    26,936.73  0.0340  0.0751  0.0371  0.0376  0.0435  0.0474  0.0684  ±0.11%    13469
   · encodeInto 50K length string    4,903.32  0.1907  0.3976  0.2039  0.2037  0.2447  0.2831  0.3556  ±0.27%     2452

 ✓ src/index.bench.mts > MUtf8Encoder.encodeInto > Mixed text 1945ms
     name                                  hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · encodeInto 500 length string  505,363.12  0.0018  0.3494  0.0020  0.0020  0.0023  0.0026  0.0036  ±0.14%   252682
   · encodeInto 5K length string    51,134.50  0.0182  0.1475  0.0196  0.0197  0.0230  0.0246  0.0292  ±0.08%    25568
   · encodeInto 50K length string    5,052.23  0.1873  0.3217  0.1979  0.1992  0.2257  0.2330  0.2624  ±0.17%     2527
```